### PR TITLE
bugfix(dpav-2072): property type fix

### DIFF
--- a/.github/workflows/oss-checker.yml
+++ b/.github/workflows/oss-checker.yml
@@ -327,7 +327,7 @@ jobs:
 
       - name: Upload OSS result artifacts
         if: ${{ steps.summarise_results.outputs.hasResults == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: oss-checks-${{ github.run_id }}
           retention-days: 30

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -72,7 +72,7 @@ jobs:
           echo "$api_response" | jq '.sbom' > sbom.spdx.json
 
       - name: Upload SBOM Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: sbom
           path: sbom.spdx.json
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download SBOM Artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: sbom
 

--- a/dbt-pipeline/dbt-epc/models/int_epc_address_features.sql
+++ b/dbt-pipeline/dbt-epc/models/int_epc_address_features.sql
@@ -1,7 +1,16 @@
-{{ config(materialized='view') }}
+{{ config(materialized="view") }}
 
 -- Map raw split fields into normalized feature columns.
-
+with
+    constants as (
+        select
+            '%double%' as double_pattern,
+            '%assumed%' as assumed_pattern,
+            '%no insulation%' as no_insulation_pattern,
+            '%filled cavity%' as filled_cavity_pattern,
+            'InsulatedWall' as insulated_wall_value,
+            'MechanicalSupplyAndExtract' as mechanical_supply_and_extract_value
+    )
 select
     lmk_key,
     uprn,
@@ -10,8 +19,12 @@ select
     current_energy_efficiency as saprating,
     current_energy_rating as sapband,
     lodgement_date,
-    trim(regexp_replace(construction_age_band, '^\s*England and Wales:\s*', '', 'i')) as construction_age_band,
-    nullif(regexp_replace(initcap(built_form), '[^A-Za-z0-9]', '', 'g'), '') as built_form,
+    trim(
+        regexp_replace(construction_age_band, '^\s*England and Wales:\s*', '', 'i')
+    ) as construction_age_band,
+    nullif(
+        regexp_replace(initcap(built_form), '[^A-Za-z0-9]', '', 'g'), ''
+    ) as built_form,
     total_floor_area,
     environment_impact_current as environmental_impact_rating,
     co2_emissions_current as tco2,
@@ -25,122 +38,234 @@ select
     posttown,
     -- heating category (aligned with original Python mapping)
     case
-        when lower(mainheat_description) like '%boiler and radiators, mains gas%' then 'BoilerRadiatorsMainsGas'
-        when lower(mainheat_description) like '%electric storage heaters%' or lower(mainheat_description) like '%portable electric heaters%' then 'ElectricHeaters'
-        when lower(mainheat_description) like '%boiler and radiators, lpg%' or lower(mainheat_description) like '%boiler and underfloor heating, lpg%' then 'BoilerRadiatorsLPG'
-        when lower(mainheat_description) like '%boiler and radiators, oil%' or lower(mainheat_description) like '%boiler and underfloor heating, oil%' then 'BoilerRadiatorsOil'
-        when lower(mainheat_description) like '%electric underfloor heating%' then 'ElectricUnderfloor'
-        when lower(mainheat_description) like '%community scheme%' then 'CommunityScheme'
-        when lower(mainheat_description) like '%warm air, mains gas%' then 'WarmAirMainsGas'
-        when lower(mainheat_description) like '%boiler & underfloor, mains gas%' or lower(mainheat_description) like '%boiler and underfloor heating, mains gas%' then 'BoilerUnderfloorMainsGas'
-        when lower(mainheat_description) like '%air source heat pump%' then 'AirSourceHeatPump'
-        when lower(mainheat_description) like '%boiler and radiators, electric%' or lower(mainheat_description) like '%boiler and underfloor heating, electric%' then 'BoilerRadiatorsElectric'
-        when lower(mainheat_description) like '%ground source heat pump%' then 'GroundSourceHeatPump'
-        when lower(mainheat_description) like '%boiler and radiators, dual fuel%' then 'BoilerRadiatorsDualFuel'
-        when lower(mainheat_description) like '%boiler and radiators, wood%' then 'BoilerRadiatorsWood'
-        when lower(mainheat_description) like '%room heaters, mains gas%' then 'RoomHeatersMainsGas'
-        when lower(mainheat_description) like '%no system present%' then 'NoSystemPresent'
-        when lower(mainheat_description) like '%water source heat pump%' then 'WaterSourceHeatPump'
+        when lower(mainheat_description) like '%boiler and radiators, mains gas%'
+        then 'BoilerRadiatorsMainsGas'
+        when
+            lower(mainheat_description) like '%electric storage heaters%'
+            or lower(mainheat_description) like '%portable electric heaters%'
+        then 'ElectricHeaters'
+        when
+            lower(mainheat_description) like '%boiler and radiators, lpg%'
+            or lower(mainheat_description) like '%boiler and underfloor heating, lpg%'
+        then 'BoilerRadiatorsLPG'
+        when
+            lower(mainheat_description) like '%boiler and radiators, oil%'
+            or lower(mainheat_description) like '%boiler and underfloor heating, oil%'
+        then 'BoilerRadiatorsOil'
+        when lower(mainheat_description) like '%electric underfloor heating%'
+        then 'ElectricUnderfloor'
+        when lower(mainheat_description) like '%community scheme%'
+        then 'CommunityScheme'
+        when lower(mainheat_description) like '%warm air, mains gas%'
+        then 'WarmAirMainsGas'
+        when
+            lower(mainheat_description) like '%boiler & underfloor, mains gas%'
+            or lower(mainheat_description)
+            like '%boiler and underfloor heating, mains gas%'
+        then 'BoilerUnderfloorMainsGas'
+        when lower(mainheat_description) like '%air source heat pump%'
+        then 'AirSourceHeatPump'
+        when
+            lower(mainheat_description) like '%boiler and radiators, electric%'
+            or lower(mainheat_description)
+            like '%boiler and underfloor heating, electric%'
+        then 'BoilerRadiatorsElectric'
+        when lower(mainheat_description) like '%ground source heat pump%'
+        then 'GroundSourceHeatPump'
+        when lower(mainheat_description) like '%boiler and radiators, dual fuel%'
+        then 'BoilerRadiatorsDualFuel'
+        when lower(mainheat_description) like '%boiler and radiators, wood%'
+        then 'BoilerRadiatorsWood'
+        when lower(mainheat_description) like '%room heaters, mains gas%'
+        then 'RoomHeatersMainsGas'
+        when lower(mainheat_description) like '%no system present%'
+        then 'NoSystemPresent'
+        when lower(mainheat_description) like '%water source heat pump%'
+        then 'WaterSourceHeatPump'
         else 'Other'
     end as main_heating_category,
     -- fuel category mapped to final fuel_type_map targets
     case
-        when main_fuel ilike '%mains gas%' then 'NaturalFuelGas'
-        when main_fuel ilike '%electricity%' or main_fuel ilike '%electric%' then 'Electricity'
-        when main_fuel ilike '%oil%' then 'Oil'
-        when main_fuel ilike '%lpg%' then 'LPG'
-        when main_fuel ilike '%dual fuel%' then 'Fuel'
-        when main_fuel ilike '%wood logs%' then 'WoodLogs'
-        when main_fuel ilike '%wood pellets%' then 'WoodPellets'
-        when main_fuel ilike '%wood chips%' then 'WoodChips'
-        when main_fuel ilike '%house coal%' then 'Coal'
-        when main_fuel ilike '%anthracite%' then 'Anthracite'
-        when main_fuel ilike '%smokeless coal%' then 'SmokelessCoal'
-        when main_fuel ilike '%biomass%' then 'Biomass'
-        when main_fuel ilike '%biogas%' then 'Fuel'
-        when main_fuel ilike '%no heating/hot-water system%' then 'Fuel'
-        when main_fuel ilike '%invalid%' then 'Fuel'
+        when main_fuel ilike '%mains gas%'
+        then 'NaturalFuelGas'
+        when main_fuel ilike '%electricity%' or main_fuel ilike '%electric%'
+        then 'Electricity'
+        when main_fuel ilike '%oil%'
+        then 'Oil'
+        when main_fuel ilike '%lpg%'
+        then 'LPG'
+        when main_fuel ilike '%dual fuel%'
+        then 'Fuel'
+        when main_fuel ilike '%wood logs%'
+        then 'WoodLogs'
+        when main_fuel ilike '%wood pellets%'
+        then 'WoodPellets'
+        when main_fuel ilike '%wood chips%'
+        then 'WoodChips'
+        when main_fuel ilike '%house coal%'
+        then 'Coal'
+        when main_fuel ilike '%anthracite%'
+        then 'Anthracite'
+        when main_fuel ilike '%smokeless coal%'
+        then 'SmokelessCoal'
+        when main_fuel ilike '%biomass%'
+        then 'Biomass'
+        when main_fuel ilike '%biogas%'
+        then 'Fuel'
+        when main_fuel ilike '%no heating/hot-water system%'
+        then 'Fuel'
+        when main_fuel ilike '%invalid%'
+        then 'Fuel'
         else 'Fuel'
     end as main_fuel_type,
     -- glazing
     case
-        when glazed_type ilike '%double%' and glazed_type ilike '%before%2002%' then 'DoubleGlazingBefore2002'
-        when glazed_type ilike '%double%' and glazed_type ilike '%2002%' then 'DoubleGlazingAfter2002'
-        when glazed_type ilike '%double%' then 'DoubleGlazing'
-        when glazed_type ilike '%triple%' then 'TripleGlazing'
-        when glazed_type ilike '%secondary%' then 'SecondaryGlazing'
-        when glazed_type ilike '%single%' then 'SingleGlazing'
+        when glazed_type ilike c.double_pattern and glazed_type ilike '%before%2002%'
+        then 'DoubleGlazingBefore2002'
+        when glazed_type ilike c.double_pattern and glazed_type ilike '%2002%'
+        then 'DoubleGlazingAfter2002'
+        when glazed_type ilike c.double_pattern
+        then 'DoubleGlazing'
+        when glazed_type ilike '%triple%'
+        then 'TripleGlazing'
+        when glazed_type ilike '%secondary%'
+        then 'SecondaryGlazing'
+        when glazed_type ilike '%single%'
+        then 'SingleGlazing'
         else null
     end as multiple_glazing_type,
     -- roof mappings
     case
-        when roof_construction_raw ilike '%flat%' then 'FlatRoof'
-        when roof_construction_raw ilike '%another dwelling above%' then 'AnotherDwellingAbove'
-        when roof_construction_raw ilike '%other premises above%' then 'OtherPremisesAbove'
-        when roof_construction_raw ilike '%pitched%' then 'PitchedRoof'
-        when roof_construction_raw ilike '%roof room%' then 'RoofRooms'
-        when roof_construction_raw ilike '%thatched%' then 'ThatchedRoof'
+        when roof_construction_raw ilike '%flat%'
+        then 'FlatRoof'
+        when roof_construction_raw ilike '%another dwelling above%'
+        then 'AnotherDwellingAbove'
+        when roof_construction_raw ilike '%other premises above%'
+        then 'OtherPremisesAbove'
+        when roof_construction_raw ilike '%pitched%'
+        then 'PitchedRoof'
+        when roof_construction_raw ilike '%roof room%'
+        then 'RoofRooms'
+        when roof_construction_raw ilike '%thatched%'
+        then 'ThatchedRoof'
         else null
     end as roof_construction,
     case
-        when roof_insulation_raw ilike '%mm%' then regexp_replace(roof_insulation_raw, '[^0-9+]', '', 'g') || 'mm'
+        when roof_insulation_raw ilike '%mm%'
+        then regexp_replace(roof_insulation_raw, '[^0-9+]', '', 'g') || 'mm'
         else null
     end as roof_insulation_thickness,
     case
-        when roof_insulation_raw is null or trim(roof_insulation_raw) = '' then null
-        when roof_insulation_raw ilike '%rafters%' then 'InsulatedAtRafters'
-        when roof_insulation_raw ilike '%ceiling insulated%' then 'CeilingInsulated'
-        when roof_insulation_raw ilike '%flat roof%' then 'FlatRoofInsulation'
-        when roof_insulation_raw ilike '%with additional insulation%' then 'ThatchedWithAdditionalInsulation'
-        when roof_insulation_raw ilike '%thatched%' then 'InsulatedWithThatched'
-        when roof_insulation_raw ilike '%limited insulation%' and roof_insulation_raw ilike '%assumed%' then 'LimitedInsulationAssumed'
-        when roof_insulation_raw ilike '%limited insulation%' then 'LimitedInsulation'
-        when roof_insulation_raw ilike '%insulated%' and roof_insulation_raw ilike '%assumed%' then 'InsulatedAssumed'
-        when roof_insulation_raw ilike '%insulated%' then 'Insulated'
-        when roof_insulation_raw ilike '%loft insulation%' and roof_insulation_raw ilike '%assumed%' then 'LoftInsulationAssumed'
-        when roof_insulation_raw ilike '%loft insulation%' then 'LoftInsulation'
-        when roof_insulation_raw ilike '%no insulation%' and roof_insulation_raw ilike '%assumed%' then 'NoInsulationAssumedInRoof'
-        when roof_insulation_raw ilike '%no insulation%' then 'NoInsulationInRoof'
-        when roof_insulation_raw ilike '%unknown%' then null
+        when roof_insulation_raw is null or trim(roof_insulation_raw) = ''
+        then null
+        when roof_insulation_raw ilike '%rafters%'
+        then 'InsulatedAtRafters'
+        when roof_insulation_raw ilike '%ceiling insulated%'
+        then 'CeilingInsulated'
+        when roof_insulation_raw ilike '%flat roof%'
+        then 'FlatRoofInsulation'
+        when roof_insulation_raw ilike '%with additional insulation%'
+        then 'ThatchedWithAdditionalInsulation'
+        when roof_insulation_raw ilike '%thatched%'
+        then 'InsulatedWithThatched'
+        when
+            roof_insulation_raw ilike '%limited insulation%'
+            and roof_insulation_raw ilike c.assumed_pattern
+        then 'LimitedInsulationAssumed'
+        when roof_insulation_raw ilike '%limited insulation%'
+        then 'LimitedInsulation'
+        when
+            roof_insulation_raw ilike '%insulated%'
+            and roof_insulation_raw ilike c.assumed_pattern
+        then 'InsulatedAssumed'
+        when roof_insulation_raw ilike '%insulated%'
+        then 'Insulated'
+        when
+            roof_insulation_raw ilike '%loft insulation%'
+            and roof_insulation_raw ilike c.assumed_pattern
+        then 'LoftInsulationAssumed'
+        when roof_insulation_raw ilike '%loft insulation%'
+        then 'LoftInsulation'
+        when
+            roof_insulation_raw ilike c.no_insulation_pattern
+            and roof_insulation_raw ilike c.assumed_pattern
+        then 'NoInsulationAssumedInRoof'
+        when roof_insulation_raw ilike c.no_insulation_pattern
+        then 'NoInsulationInRoof'
+        when roof_insulation_raw ilike '%unknown%'
+        then null
         else nullif(trim(roof_insulation_extra), '')
     end as roof_insulation_location,
     -- wall mappings (aligned to original Python transform_wall_construction)
     case
-        when wall_construction_raw ilike '%cavity wall%' then 'CavityWall'
-        when wall_construction_raw ilike '%timber frame%' then 'TimberFrame'
-        when wall_construction_raw ilike '%solid brick%' then 'SolidBrick'
-        when wall_construction_raw ilike '%sandstone or limestone%' then 'SandstoneOrLimestone'
-        when wall_construction_raw ilike '%sandstone%' then 'Sandstone'
-        when wall_construction_raw ilike '%granite%' or wall_construction_raw ilike '%whin%' then 'GraniteOrWhinstone'
-        when wall_construction_raw ilike '%park home wall%' then 'ParkHomeWall'
-        when wall_construction_raw ilike '%cob%' then 'Cob'
-        when wall_construction_raw ilike '%system built%' then 'SystemBuilt'
+        when wall_construction_raw ilike '%cavity wall%'
+        then 'CavityWall'
+        when wall_construction_raw ilike '%timber frame%'
+        then 'TimberFrame'
+        when wall_construction_raw ilike '%solid brick%'
+        then 'SolidBrick'
+        when wall_construction_raw ilike '%sandstone or limestone%'
+        then 'SandstoneOrLimestone'
+        when wall_construction_raw ilike '%sandstone%'
+        then 'Sandstone'
+        when
+            wall_construction_raw ilike '%granite%'
+            or wall_construction_raw ilike '%whin%'
+        then 'GraniteOrWhinstone'
+        when wall_construction_raw ilike '%park home wall%'
+        then 'ParkHomeWall'
+        when wall_construction_raw ilike '%cob%'
+        then 'Cob'
+        when wall_construction_raw ilike '%system built%'
+        then 'SystemBuilt'
         else 'Other'
     end as wall_construction,
     case
-        when wall_insulation_raw ilike '%filled cavity%' and wall_insulation_raw ilike '%internal%' then 'InternalInsulation'
-        when wall_insulation_raw ilike '%filled cavity%' and wall_insulation_raw ilike '%external%' then 'ExternalInsulation'
-        when wall_insulation_raw ilike '%filled cavity%' then 'InsulatedWall'
-        when wall_insulation_raw ilike '%internal%' then 'InternalInsulation'
-        when wall_insulation_raw ilike '%external%' then 'ExternalInsulation'
-        when wall_insulation_raw ilike '%additional insulation%' then 'InsulatedWall'
-        when wall_insulation_raw ilike '%as built%' then 'InsulatedWall'
-        when wall_insulation_raw ilike '%partial%' then 'PartialInsulation'
-        when wall_insulation_raw is null or trim(wall_insulation_raw) = '' then 'NoInsulationInWall'
+        when
+            wall_insulation_raw ilike c.filled_cavity_pattern
+            and wall_insulation_raw ilike '%internal%'
+        then 'InternalInsulation'
+        when
+            wall_insulation_raw ilike c.filled_cavity_pattern
+            and wall_insulation_raw ilike '%external%'
+        then 'ExternalInsulation'
+        when wall_insulation_raw ilike c.filled_cavity_pattern
+        then c.insulated_wall_value
+        when wall_insulation_raw ilike '%internal%'
+        then 'InternalInsulation'
+        when wall_insulation_raw ilike '%external%'
+        then 'ExternalInsulation'
+        when wall_insulation_raw ilike '%additional insulation%'
+        then c.insulated_wall_value
+        when wall_insulation_raw ilike '%as built%'
+        then c.insulated_wall_value
+        when wall_insulation_raw ilike '%partial%'
+        then 'PartialInsulation'
+        when wall_insulation_raw is null or trim(wall_insulation_raw) = ''
+        then 'NoInsulationInWall'
         else 'WallInsulation'
     end as wall_insulation_type,
     -- floor mappings
     case
-        when floor_construction_raw ilike '%solid%' then 'Solid'
-        when floor_construction_raw ilike '%suspended%' then 'Suspended'
-        when floor_construction_raw ilike '%another dwelling below%' then 'AnotherDwellingBelow'
-        when floor_construction_raw ilike '%other premises below%' then 'OtherPremisesBelow'
+        when floor_construction_raw ilike '%solid%'
+        then 'Solid'
+        when floor_construction_raw ilike '%suspended%'
+        then 'Suspended'
+        when floor_construction_raw ilike '%another dwelling below%'
+        then 'AnotherDwellingBelow'
+        when floor_construction_raw ilike '%other premises below%'
+        then 'OtherPremisesBelow'
         else null
     end as floor_construction,
     case
-        when floor_insulation_raw ilike '%no insulation%' or floor_insulation_raw ilike '%uninsulated%' then 'NoInsulationInFloor'
-        when floor_insulation_raw ilike '%limited%' then 'LimitedFloorInsulation'
-        when floor_insulation_raw is null or trim(floor_insulation_raw) = '' then null
+        when
+            floor_insulation_raw ilike c.no_insulation_pattern
+            or floor_insulation_raw ilike '%uninsulated%'
+        then 'NoInsulationInFloor'
+        when floor_insulation_raw ilike '%limited%'
+        then 'LimitedFloorInsulation'
+        when floor_insulation_raw is null or trim(floor_insulation_raw) = ''
+        then null
         else 'InsulatedFloor'
     end as floor_insulation,
     windows_description,
@@ -148,12 +273,21 @@ select
     number_open_fireplaces as open_fireplaces_count,
     wind_turbine_count as renewables,
     case
-        when mechanical_ventilation ilike '%mechanical supply and extract%' then 'MechanicalSupplyAndExtract'
-        when mechanical_ventilation ilike '%mechanical%' and mechanical_ventilation ilike '%supply%' and mechanical_ventilation ilike '%extract%' then 'MechanicalSupplyAndExtract'
-        when mechanical_ventilation ilike '%mechanical ventilation%' then 'MechanicalSupplyAndExtract'
-        when mechanical_ventilation ilike '%mechanical extract%' then 'MechanicalExtractOnly'
-        when mechanical_ventilation ilike '%mechanical%' then 'MechanicalExtractOnly'
+        when mechanical_ventilation ilike '%mechanical supply and extract%'
+        then c.mechanical_supply_and_extract_value
+        when
+            mechanical_ventilation ilike '%mechanical%'
+            and mechanical_ventilation ilike '%supply%'
+            and mechanical_ventilation ilike '%extract%'
+        then c.mechanical_supply_and_extract_value
+        when mechanical_ventilation ilike '%mechanical ventilation%'
+        then c.mechanical_supply_and_extract_value
+        when mechanical_ventilation ilike '%mechanical extract%'
+        then 'MechanicalExtractOnly'
+        when mechanical_ventilation ilike '%mechanical%'
+        then 'MechanicalExtractOnly'
         else 'NaturalVentilation'
     end as ventilation,
     certificate_type
-from {{ ref('int_epc_address_split') }}
+from {{ ref("int_epc_address_split") }}, constants c
+

--- a/dbt-pipeline/dbt-epc/models/int_epc_address_features.sql
+++ b/dbt-pipeline/dbt-epc/models/int_epc_address_features.sql
@@ -18,7 +18,10 @@ select
     heating_cost_current as heating_cost_gbp_per_yr,
     hot_water_cost_current as water_heating_cost_gbp_per_yr,
     lighting_cost_current as lighting_cost_gbp_per_yr,
-    property_type,
+    case
+        when property_type ilike '% %' then regexp_replace(initcap(trim(property_type)), '\s+', '', 'g')
+        else property_type
+    end as property_type,
     posttown,
     -- heating category (aligned with original Python mapping)
     case

--- a/dbt-pipeline/dbt-epc/models/stg_epc_certificates.yml
+++ b/dbt-pipeline/dbt-epc/models/stg_epc_certificates.yml
@@ -108,7 +108,9 @@ models:
         description: The date that the inspection was actually carried out by the energy assessor
         field_type: DATE
         tests:
-          - not_null
+          - not_null:
+              config:
+                severity: warn
       - name: local_authority
         description: Office for National Statistics (ONS) code. Local authority area in which the building is located.
         field_type: TEXT
@@ -198,6 +200,8 @@ models:
                 - Y
                 - N
                 - null
+              config:
+                severity: warn
       - name: flat_storey_count
         description: The number of storeys in the apartment block.
         field_type: INT
@@ -222,6 +226,8 @@ models:
                 - Less Than Typical
                 - Much Less Than Typical
                 - null
+              config:
+                severity: warn
       - name: extension_count
         description: The number of extensions added to the property.
         field_type: FLOAT
@@ -252,6 +258,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: hot_water_env_eff
         description: Environmental efficiency rating. On actual energy certificate shown as one to five star rating.
         field_type: TEXT
@@ -264,6 +272,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: floor_description
         description: Overall description of the property feature
         field_type: TEXT
@@ -279,6 +289,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: windows_description
         description: Overall description of the property feature
         field_type: TEXT
@@ -294,6 +306,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: windows_env_eff
         description: Environmental efficiency rating. On actual energy certificate shown as one to five star rating.
         field_type: TEXT
@@ -306,6 +320,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: walls_description
         description: Overall description of the property feature
         field_type: TEXT
@@ -321,6 +337,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: walls_env_eff
         description: Environmental efficiency rating. On actual energy certificate shown as one to five star rating.
         field_type: TEXT
@@ -333,6 +351,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: secondheat_description
         description: Overall description of the property feature
         field_type: TEXT
@@ -348,6 +368,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: sheating_env_eff
         description: Energy efficiency rating. On actual energy certificate shown as one to five star rating.
         field_type: TEXT
@@ -360,6 +382,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: roof_description
         description: Overall description of the property feature
         field_type: TEXT
@@ -375,6 +399,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: roof_env_eff
         description: Energy efficiency rating. On actual energy certificate shown as one to five star rating.
         field_type: TEXT
@@ -387,6 +413,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: mainheat_energy_eff
         description: Energy efficiency rating. On actual energy certificate shown as one to five star rating.
         field_type: TEXT
@@ -399,6 +427,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: mainheat_env_eff
         description: Environmental efficiency rating. On actual energy certificate shown as one to five star rating.
         field_type: TEXT
@@ -411,6 +441,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: mainheatcont_description
         description: Overall description of the property feature.
         field_type: TEXT
@@ -426,6 +458,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: mainheatc_env_eff
         description: Environmental efficiency rating. On actual energy certificate shown as one to five star rating.
         field_type: TEXT
@@ -438,6 +472,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: lighting_description
         description:
           Overall description of property feature. Total number of fixed lighting outlets and total number of low-energy
@@ -455,6 +491,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: lighting_env_eff
         description: Energy efficiency rating. On actual energy certificate shown as one to five star rating.
         field_type: TEXT
@@ -467,6 +505,8 @@ models:
                 - Poor
                 - Very Poor
                 - null
+              config:
+                severity: warn
       - name: main_fuel
         description: The type of fuel used to power the central heating e.g. Gas, Electricity
         field_type: TEXT
@@ -496,6 +536,8 @@ models:
                 - Y
                 - N
                 - null
+              config:
+                severity: warn
       - name: mechanical_ventilation
         description: Identifies the type of mechanical ventilation the property has. This is required for the RdSAP calculation.
         field_type: TEXT


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The address profiling mapper fails if values for property type contain whitespace. In particular, the value "Park home" was causing the mapper to fail. This change ensures any values with a whitespace are kamel cased which prevents this issue in the mapper downstream. 

<!--- If it fixes an open issue, please link to the issue here. -->

## Description
<!--- Describe your changes in detail -->
Change to int_epc_address_features.sql to camel case the property type feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested locally with dbt-epc and the address profiling mapper running successfully against all Isle of Wight data. No records were passed to the dead letter queue as part of the mapping process any longer.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.